### PR TITLE
bug fix - init data object before use

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -350,6 +350,8 @@ static NSString* toBase64(NSData* data) {
                 // use image unedited as requested , don't resize
                 data = UIImageJPEGRepresentation(image, 1.0);
             } else {
+                data = UIImageJPEGRepresentation(image, [options.quality floatValue] / 100.0f);
+                
                 if (options.usesGeolocation) {
                     NSDictionary* controllerMetadata = [info objectForKey:@"UIImagePickerControllerMediaMetadata"];
                     if (controllerMetadata) {
@@ -366,8 +368,6 @@ static NSString* toBase64(NSData* data) {
                         }
                         [[self locationManager] startUpdatingLocation];
                     }
-                } else {
-                    data = UIImageJPEGRepresentation(image, [options.quality floatValue] / 100.0f);
                 }
             }
         }


### PR DESCRIPTION
In case of "options.usesGeolocation" is enabled, unprocessed data is assigned to self.data.
To fix, initialize data object before checking "options.usesGeolocation" status.